### PR TITLE
fix: improve collection card error compatibility

### DIFF
--- a/assets/collection-pcard-error.js
+++ b/assets/collection-pcard-error.js
@@ -12,7 +12,12 @@ class CollectionPCardError {
     }
   }
   removeDiacritics(text) {
-    return text && text.normalize('NFD').replace(/\p{Diacritic}/gu, '');
+    if (!text) return text;
+    try {
+      return text.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+    } catch (e) {
+      return text;
+    }
   }
   show(msg) {
     if (!this.node) return;


### PR DESCRIPTION
## Summary
- ensure `CollectionPCardError` removes diacritics without Unicode property escapes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68968b71ebd8832d819a3208bc1252d0