### PR TITLE
style: adjust search form styling

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -91,3 +91,16 @@
 .collection-pcard-error__msg {
   display: block;
 }
+
+/* Search form custom styling */
+.sf-search-form {
+  height: 46px;
+}
+
+.border-color-border {
+  border-color: #000000;
+}
+
+.border {
+  border-width: 2px;
+}

--- a/assets/custom.css.liquid
+++ b/assets/custom.css.liquid
@@ -94,3 +94,16 @@
 .collection-pcard-error__msg {
   display: block;
 }
+
+/* Search form custom styling */
+.sf-search-form {
+  height: 46px;
+}
+
+.border-color-border {
+  border-color: #000000;
+}
+
+.border {
+  border-width: 2px;
+}


### PR DESCRIPTION
## Summary
- add custom CSS to give search form a fixed height and border styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896ae58bec8832d9c3566bb28e9d90b