### PR TITLE
feat: refine search bar and collection add-to-cart

### DIFF
--- a/assets/collection-quick-add.css
+++ b/assets/collection-quick-add.css
@@ -49,6 +49,10 @@ input.collection-qty-element:focus {
 .collection-product-form.adding .atc-text { visibility: hidden; }
 .collection-product-form.adding .add-to-cart { pointer-events: none; }
 
+.add-to-cart[aria-busy="true"] .atc-spinner { display: flex; }
+.add-to-cart[aria-busy="true"] .atc-text { visibility: hidden; }
+.add-to-cart[aria-busy="true"] { pointer-events: none; }
+
 /* layout tweaks for quantity controls inside quick-add cards */
 .collection-qty-group {
   flex-wrap: wrap;

--- a/assets/collection-quick-add.js
+++ b/assets/collection-quick-add.js
@@ -557,6 +557,10 @@ async function handleDelegatedAddToCart(e){
       this.addEventListener('submit', this.onSubmit.bind(this));
     }
     toggleSpinner(show){
+      if(this.submitButton){
+        this.submitButton.toggleAttribute('aria-busy', show);
+        this.submitButton.disabled = show;
+      }
       this.classList[show ? 'add' : 'remove']('adding');
     }
     async onSubmit(e){

--- a/assets/custom.css
+++ b/assets/custom.css
@@ -91,3 +91,23 @@
 .collection-pcard-error__msg {
   display: block;
 }
+
+/* Search form custom styling */
+.sf-search-form {
+  height: 46px;
+}
+
+/* limit border styling to the search form */
+.sf-search-form.border {
+  border-width: 2px;
+}
+
+.sf-search-form.border-color-border {
+  border-color: #000000;
+}
+
+/* search popup form */
+[data-search-popup] form {
+  height: 50px;
+  border-width: 2px;
+}

--- a/assets/custom.css.liquid
+++ b/assets/custom.css.liquid
@@ -94,3 +94,23 @@
 .collection-pcard-error__msg {
   display: block;
 }
+
+/* Search form custom styling */
+.sf-search-form {
+  height: 46px;
+}
+
+/* limit border styling to the search form */
+.sf-search-form.border {
+  border-width: 2px;
+}
+
+.sf-search-form.border-color-border {
+  border-color: #000000;
+}
+
+/* search popup form */
+[data-search-popup] form {
+  height: 50px;
+  border-width: 2px;
+}


### PR DESCRIPTION
## Summary
- limit border styling to the search form and search popup form
- set consistent heights for search form and popup
- show spinner and disable button while collection quick-add requests are pending

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896ae58bec8832d9c3566bb28e9d90b