### PR TITLE
Fix sticky add-to-cart button width

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -111,3 +111,7 @@
   height: 50px;
   border-width: 2px;
 }
+
+.prod__sticky-atc .sf__btn.add-to-cart {
+  min-width: auto; /* or 0 to fully reset */
+}

--- a/assets/custom.css.liquid
+++ b/assets/custom.css.liquid
@@ -114,3 +114,7 @@
   height: 50px;
   border-width: 2px;
 }
+
+.prod__sticky-atc .sf__btn.add-to-cart {
+  min-width: auto; /* or 0 to fully reset */
+}


### PR DESCRIPTION
## Summary
- ensure sticky add-to-cart button doesn't enforce a minimum width so text centers correctly

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896bcc40440832da450aea930e4a62a